### PR TITLE
changes to make character sheet work easier

### DIFF
--- a/dungeoneerClient/src/app/app-routing.module.ts
+++ b/dungeoneerClient/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ import { DmMainComponent } from './routes/dm-main/dm-main.component';
 
 const routes: Routes = [
   { path: '', component: DmMainComponent },
-  { path: 'characterSheet', component: DmCharacterSheetComponent }
+  { path: 'characterSheet/:uid', component: DmCharacterSheetComponent }
 ];
 
 @NgModule({

--- a/dungeoneerClient/src/app/routes/dm-main/dm-main.component.ts
+++ b/dungeoneerClient/src/app/routes/dm-main/dm-main.component.ts
@@ -25,7 +25,7 @@ export class DmMainComponent implements OnInit {
   }
 
   onViewCharacterSheet() {
-    this.router.navigate(['characterSheet'])
+    this.router.navigate(['characterSheet', this.currentCharacter.uid])
   }
 
 }

--- a/dungeoneerServer/package.json
+++ b/dungeoneerServer/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest",
-    "dev": "nodemon dist/index.js",
+    "dev": "nodemon --watch ../dungeoneerCommon dist/index.js",
     "watch": "tsc --watch --project tsconfig-build.json"
   },
   "jest": {


### PR DESCRIPTION
I made a couple of quick changes that should make the character sheet work easier for you

Change 1:

A tiny change in the package.json for dungeoneerServer so that the dev command looks like this:

    nodemon --watch ../dungeoneerCommon dist/index.js

This ensures that nodemon restarts the server when changes are made to dungeoneerCommon (adding attributes to the schema for example)

Change 2:

When you click "view character sheet" in the main route, it now passes the uid of the character as a url parameter. So when in character sheet view, instead of relying on "currentCharacter" being set in the data-store, it fetches that data itself. This means any changes made in the client (causing ng serve to refresh) will keep the character data available in the character sheet route. Should make changes much easier to test.

That said, if you've already made any changes to the character sheet view, you may need to handle some merge conflicts. nothing major, and it should be clear what's going. Let me know if not!