### PR TITLE
async validation!

### DIFF
--- a/dungeoneerClient/src/app/app.module.ts
+++ b/dungeoneerClient/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { Injector, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -40,7 +40,7 @@ import { DmSearchCardComponent } from './display/dm-search-card/dm-search-card.c
 import { DmCharacterSheetComponent } from './routes/dm-character-sheet/dm-character-sheet.component';
 import { DmMainComponent } from './routes/dm-main/dm-main.component';
 
-
+export let AppInjector: Injector;
 
 @NgModule({
   declarations: [
@@ -86,4 +86,8 @@ import { DmMainComponent } from './routes/dm-main/dm-main.component';
   providers: [DmDialogComponent],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+  constructor(private injector: Injector) {
+    AppInjector = this.injector;
+  }
+}

--- a/dungeoneerClient/src/app/display/dm-table-and-single-node/dm-table-and-single-node.component.ts
+++ b/dungeoneerClient/src/app/display/dm-table-and-single-node/dm-table-and-single-node.component.ts
@@ -124,7 +124,9 @@ export class DmTableAndSingleNodeComponent extends DmUnsubscriberComponent imple
   checkDblClickEdit() {
     if (this.toEdit && this.singleNodeValue && this.toEdit.uid === this.singleNodeValue.uid) {
       this.toEdit = null;
-      this.onEdit(this.singleNodeValue);
+      this.onEdit({
+        initialData: this.singleNodeValue
+      });
     }
   }
 

--- a/dungeoneerClient/src/app/form/DmFormUtils.ts
+++ b/dungeoneerClient/src/app/form/DmFormUtils.ts
@@ -1,6 +1,7 @@
-import { AbstractControl, FormControl, FormGroup, ValidatorFn, Validators } from "@angular/forms";
+import { AbstractControl, AsyncValidator, FormControl, FormGroup, ValidatorFn, Validators } from "@angular/forms";
 import { DmLinkSetParams } from "dungeoneer-common/dist/types/src/connection/connectionTypes";
 import { NodeType, NodeVar, Schema } from "dungeoneer-common/dist/types/src/schema/schemaTypes";
+import { DmUniqueValidator } from "../validation/DmUniqueValidator";
 import { DmFormInputData, DmTableInputConfig } from "./DmFormInputData";
 
 export function generateInputsFromSchema(schema: Schema, nodeType: string, initialData?: any, columns?: 'search' | string[]): DmFormInputData[] {
@@ -118,12 +119,19 @@ function getFormInputData(nodeSchema: NodeType, nodeType: string, varName: strin
 
     if (varSchema.validation && withValidation) {
         const validators: ValidatorFn[] = [];
+        const asyncValidators: any[] = []
 
         if (varSchema.validation.required) {
             validators.push(Validators.required);
         }
 
+        if (varSchema.validation.unique) {
+          asyncValidators.push(new DmUniqueValidator(nodeType, varName, initialData));
+        }
+
         abstractControl.addValidators(validators);
+
+        abstractControl.addAsyncValidators(asyncValidators);
     }
 
     const formInputData: DmFormInputData = {

--- a/dungeoneerClient/src/app/form/dm-form-dialog/dm-form-dialog.component.ts
+++ b/dungeoneerClient/src/app/form/dm-form-dialog/dm-form-dialog.component.ts
@@ -16,6 +16,7 @@ export class DmFormDialogComponent extends DmFormComponent implements OnInit {
   dmDialog?: DmDialogComponent;
 
   saveButtonClass: string = 'mat-primary';
+  formValid: boolean = false;
 
   constructor() {
     super();
@@ -24,15 +25,11 @@ export class DmFormDialogComponent extends DmFormComponent implements OnInit {
   override ngOnInit(): void {
     super.ngOnInit();
 
-    this.formGroup.valueChanges.pipe(distinctUntilChanged((a: any, b: any) => {
-      return JSON.stringify(a) === JSON.stringify(b)
-    }),takeUntil(this.unsubscribeAll)).subscribe((data) => {
+    this.formGroup.statusChanges.pipe(distinctUntilChanged(),takeUntil(this.unsubscribeAll)).subscribe((data) => {
       this.checkSaveButtonClass();
     });
 
-    setTimeout(() => {
-      this.checkSaveButtonClass();
-    });
+    this.checkSaveButtonClass();
     
   }
 
@@ -56,13 +53,15 @@ export class DmFormDialogComponent extends DmFormComponent implements OnInit {
   }
 
   checkSaveButtonClass() {
-    console.log('checking save button class', this.formGroup.value);
-    const saveClass: string = this.formGroup.valid ? 'mat-primary' : 'mat-warn';
-    if (saveClass !== this.saveButtonClass) {
-      console.log('setting save class', this.saveButtonClass, saveClass);
-      this.saveButtonClass = saveClass;
-      //this.changeDetectorRef.detectChanges();
-    }
+    setTimeout(() => {
+      console.log('checking save button class', this.formGroup.valid, this.formGroup.value, this.formGroup);
+      const saveClass: string = this.formGroup.valid ? 'mat-primary' : 'mat-warn';
+      if (saveClass !== this.saveButtonClass) {
+        console.log('setting save class to', saveClass);
+        this.saveButtonClass = saveClass;
+        //this.changeDetectorRef.detectChanges();
+      }
+    });
   }
 
 }

--- a/dungeoneerClient/src/app/validation/DmUniqueValidator.ts
+++ b/dungeoneerClient/src/app/validation/DmUniqueValidator.ts
@@ -1,0 +1,83 @@
+import { AbstractControl, AsyncValidator, ValidationErrors } from "@angular/forms";
+import { DmFetchParams, DmResponse } from "dungeoneer-common/dist/types/src/connection/connectionTypes";
+import { Observable } from "rxjs";
+import { AppInjector } from "../app.module";
+import { DmWebSocketService } from "../connection/dm-web-socket.service";
+
+export class DmUniqueValidator implements AsyncValidator {
+
+    nodeType: string;
+    key: string;
+    uid!: string;
+
+    dmWebSocketClient: DmWebSocketService;
+
+    currentPromise!: Promise<ValidationErrors | null> | Observable<any | ValidationErrors | null>
+    prevValue: any;
+
+    constructor(nodeType: string, key: string, inputData: any) {
+        this.nodeType = nodeType;
+        this.key = key;
+
+        this.dmWebSocketClient = AppInjector.get(DmWebSocketService);
+
+        console.log('input data', inputData);
+        // if we are editing, store the uid of the item we are editing.
+        if (inputData && inputData.uid) {
+            this.uid = inputData.uid;
+        }
+    }
+
+    validate(ctrl: AbstractControl): Promise<ValidationErrors | null> | Observable<any | ValidationErrors | null> {
+        if (this.prevValue === ctrl.value && this.currentPromise) {
+            return this.currentPromise;
+        }
+        this.prevValue = ctrl.value;
+        // create a case insensitive equality search
+        const fetchParams: DmFetchParams = {
+            nodeType: this.nodeType,
+            search: {
+                [this.key]: ctrl.value || ""
+            },
+            filterOverride: {
+                [this.key]: 'eq/i'
+            }
+        }
+
+        this.currentPromise = new Promise(resolve => {
+            this.dmWebSocketClient.sendRequest({
+                method: 'fetch',
+                params: {
+                  fetch: fetchParams
+                }
+              }, (response: DmResponse) => {
+
+                // check if the search resulted in anything
+                if (response && 
+                response.result &&
+                response.result[this.nodeType] &&
+                response.result[this.nodeType].length > 0) {
+
+                    // ignore the result if it's the item we are currently editing
+                    if (this.uid &&
+                    response.result[this.nodeType].length === 1 &&
+                    response.result[this.nodeType][0].uid === this.uid) {
+                        resolve(null);
+                        return;
+                    }
+
+                    // otherwise we've failed the uniqueness test
+                    resolve({
+                        unique: {
+                            valid: false
+                        }
+                    });
+                    return;
+                }
+                resolve(null);
+            });
+        });
+
+        return this.currentPromise;
+    }
+}

--- a/dungeoneerCommon/index.ts
+++ b/dungeoneerCommon/index.ts
@@ -6,7 +6,8 @@ export const dungeoneerSchema: Schema = {
                 name: {
                     type: 'string',
                     validation: {
-                        required: true
+                        required: true,
+                        unique: true
                     }
                 },
                 weight: {

--- a/dungeoneerServer/package.json
+++ b/dungeoneerServer/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest",
-    "dev": "nodemon --watch ../dungeoneerCommon dist/index.js",
+    "dev": "nodemon --watch ../dungeoneerCommon --watch . dist/index.js",
     "watch": "tsc --watch --project tsconfig-build.json"
   },
   "jest": {


### PR DESCRIPTION
I've added a unique validation property to the 'name' attribute of items

It runs a case insensitive search on the database (had to do some modifications on the query generator to allow it) and returns invalid if the name already exists.

Another change I'd like your two cents on:

You'll notice in the uniqueness async validator, I need the DmWebsocketService to send the fetch request. But I don't want to include the service in the constructor because I don't want any component that uses FormUtils to have to inject that service to be able to generate the FormInputs.

I think I've never really figured out the point of DI. I read things like "tree shakeable" and all that, but sometimes I just want a singleton that my class or component can access without having to inject that dependency in every parent of component that calls the function in question.

In the end I use the Injector service as a variable of the module and export as a variable (based on hack found here: https://stackoverflow.com/questions/37482460/getting-instance-of-service-without-constructor-injection). No doubt this is a terrible anti-pattern, but at least it resolves my problem above. Presumably I should just completely change my design if I'm forced to do this.

Personally, I'd be perfectly happy to have the DmWebsocket not be a service, but a singleton class accessed statically. I'd appreciate your insight, and maybe finally understand why I want services in the first place!

Also this commit adds `--watch .` to the nodemon of dungeoneerServer because I think my earlier "fix" actually meant it only restarted when changes were made to dungeoneerCommon and not to dungeoneerServer itself!