### PR TITLE
Fixed bug where 0 value wasn't being displayed

### DIFF
--- a/dungeoneerClient/src/app/dm-character-sheet/dm-character-statistics/dm-character-statistics.component.html
+++ b/dungeoneerClient/src/app/dm-character-sheet/dm-character-statistics/dm-character-statistics.component.html
@@ -10,7 +10,7 @@
     </dm-character-section>
     <!-- Section: Features -->
     <dm-character-section [sectionTitle]="'Features'">
-        <dm-simple-card [label]="'Proficiency Bonus'" [value]="characterStats?.profiencyBonus"></dm-simple-card>
+        <dm-simple-card [label]="'Proficiency Bonus'" [value]="characterStats.profiencyBonus"></dm-simple-card>
         <ng-container *ngIf="characterStats?.character?.character_isJackOfAllTrades">
             <dm-nodevar-card [character]="character" [nodevarObj]="'isJackOfAllTrades'" (edit)="onValueEdit($event)">
             </dm-nodevar-card>
@@ -34,7 +34,7 @@
                 [customContent]="true">
                 <div [innerHTML]="ability | dmValue:character:schema:'character':character | dmSafeHTML">
                 </div>
-                <div>
+                <div class="isThisIt">
                     {{ability | dmValue:character:schema:'character':character | dmAbilityModifier}}
                 </div>
                 <div>

--- a/dungeoneerClient/src/app/pipes/dm-value.pipe.ts
+++ b/dungeoneerClient/src/app/pipes/dm-value.pipe.ts
@@ -12,10 +12,11 @@ export class DmValuePipe implements PipeTransform {
 
   transform(fakeKey: string, item: any, schema: any, nodeType: string, itemData?: any): string {
     if (schema.nodeTypes[nodeType]) {
-
+      console.log('fake key', fakeKey);
       const key = `${nodeType}_${fakeKey}`;
 
-      if (!item[key]) {
+      // had to use hasOwnProperty because simply using !item[key] returns flase for numerical 0
+      if (!item.hasOwnProperty(key)) {
         return '';
       }
 
@@ -26,7 +27,6 @@ export class DmValuePipe implements PipeTransform {
       if (!varSchema) {
         return key;
       }
-
       switch (varSchema.type) {
         case 'string':
           return item[key];


### PR DESCRIPTION
This bug was my fault, of course

In the `dm-value-pipe` I had to replace

```
if (!item[key]) {
      return '';
}
```

with

```
if (!item.hasOwnProperty(key)) {
     return '';
}
```

to prevent numerical values returning falsy when they are set to 0.
